### PR TITLE
Add support for PUID/PGID runtime UID switching via gosu (requires node:18)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,37 @@
-FROM node:16
+FROM node:18
+
 LABEL maintainer="kaythomas@pm.me"
+
+# Prepare node_modules with default ACLs for world readability
+RUN mkdir -p /var/noisedash/node_modules && \
+    apt-get update && apt-get install -y acl && \
+    setfacl -d -m u::rwx /var/noisedash/node_modules && \
+    setfacl -d -m g::rx /var/noisedash/node_modules && \
+    setfacl -d -m o::rx /var/noisedash/node_modules
+
 WORKDIR /var/noisedash
+
+# Install app dependencies
 COPY package*.json ./
 RUN npm install --force
+
+# Copy app source
 COPY . .
-ENV NODE_ENV production
+
+# Install gosu for UID drop at runtime
+RUN apt-get update && \
+    apt-get install -y gosu && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Build the frontend
+ENV NODE_ENV=production
 RUN npm run build
+
 EXPOSE 1432
-CMD [ "node", "server/bin/www.js" ]
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["node", "server/bin/www.js"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ docker-compose up -d
 
 (Raspberry Pi compatible images are available, see armv7 images on [Docker Hub](https://hub.docker.com/repository/docker/noisedash/noisedash))
 
+## Kubernetes
+
+You can apply the manifest.yaml in the kubernetes folder to install Noisedash into your Kubernetes cluster.
+
+Optionally, uncomment the last lines in the file to also create an ingress.  The ingress, commented out by default, needs to have the clusterIssuser annotation set to your cluster issuer (default: letsencrypt-prod) and the ingress class set to your Ingress class (default: Nginx)
+
+
+``` bash
+$ kubectl apply -f ./kubernetes/manifest.yaml
+persistentvolumeclaim/db-pvc created
+persistentvolumeclaim/samples-pvc created
+deployment.apps/noisedash created
+service/noisedash created
+configmap/noisedashcfg created
+ingress.networking.k8s.io/noisedashingress created
+```
+
 ## From Source
 
 Requires node 16 and npm

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# -------------------------------------------------------------------------------
+# ENTRYPOINT: Runtime UID/GID Switching
+# Supports running the container as any user by accepting:
+#   - PUID (default: 2000)
+#   - PGID (default: 2000)
+#   - APP_USER (default: noisedash)
+# This script ensures that the writable parts of the filesystem are owned
+# by the UID the user specified or provided via environment.
+# -------------------------------------------------------------------------------
+
+APP_USER=${APP_USER:-noisedash}
+APP_UID=${PUID:-2000}
+APP_GID=${PGID:-2000}
+
+if [ "$(id -u)" = "0" ]; then
+    echo "[INFO] Running as root. Target UID:GID → $APP_UID:$APP_GID"
+
+    # Reuse existing UID if already assigned in /etc/passwd
+    existing_user=$(getent passwd "$APP_UID" | cut -d: -f1)
+    if [ -n "$existing_user" ]; then
+        echo "[INFO] UID $APP_UID already exists as user '$existing_user'. Using it."
+        APP_USER="$existing_user"
+    else
+        # Ensure group exists
+        if ! getent group "$APP_GID" >/dev/null; then
+            echo "[INFO] Creating group '$APP_USER' with GID $APP_GID"
+            groupadd -g "$APP_GID" "$APP_USER"
+        fi
+
+        echo "[INFO] Creating user '$APP_USER' with UID $APP_UID and GID $APP_GID"
+        useradd -u "$APP_UID" -g "$APP_GID" -m -s /sbin/nologin "$APP_USER"
+    fi
+
+    # Ensure ownership of all writable paths (excluding node_modules)
+    echo "[INFO] Fixing ownership of /var/noisedash (excluding node_modules)"
+    find /var/noisedash ! -path "/var/noisedash/node_modules*" -exec chown "$APP_UID:$APP_GID" {} +
+
+    echo "[INFO] Dropping privileges to user '$APP_USER'"
+    exec gosu "$APP_USER" "$@"
+else
+    echo "[INFO] Already running as non-root (UID $(id -u)). Skipping user setup."
+    exec "$@"
+fi

--- a/kubernetes/manifest.yaml
+++ b/kubernetes/manifest.yaml
@@ -1,0 +1,240 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: samples-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: noisedash
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: noisedash
+  template:
+    metadata:
+      labels:
+        app: noisedash
+    spec:
+      containers:
+      - name: noisedash
+        image: noisedash/noisedash:latest
+        ports:
+        - containerPort: 1432
+        volumeMounts:
+        - name: db
+          mountPath: /var/noisedash/db
+        - name: samples
+          mountPath: /var/noisedash/samples
+        - name: config
+          mountPath: /var/noisedash/config/default.json
+          subPath: config.json
+      volumes:
+      - name: db
+        persistentVolumeClaim:
+          claimName: db-pvc
+      - name: samples
+        persistentVolumeClaim:
+          claimName: samples-pvc
+      - name: config
+        configMap:
+          name: noisedashcfg
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: noisedash
+spec:
+  selector:
+    app: noisedash
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 1432
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noisedashcfg
+data:
+  config.json: |
+    {
+      "Server": {
+        "listeningPort": 1432,
+        "sessionFileStorePath": "sessions",
+        "sampleUploadPath": "samples",
+        "maxSampleSize": 10737418240,
+        "logFile": "log/noisedash.log",
+        "tls": false,
+        "tlsKey": "certs/key.pem",
+        "tlsCert": "certs/cert.pem"
+      }
+    }
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  labels:
+    app.kubernetes.io/instance: noisedash
+  name: noisedashingress
+spec:
+  rules:
+  - host: noisedash.freshbrewed.science
+    http:
+      paths:
+      - backend:
+          service:
+            name: noisedash
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - noisedash.freshbrewed.science
+    secretName: noisedash-tls
+builder@DESKTOP-QADGF36:~/Workspaces/pyplanereport$
+builder@DESKTOP-QADGF36:~/Workspaces/pyplanereport$ cat noiseall.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: samples-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: noisedash
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: noisedash
+  template:
+    metadata:
+      labels:
+        app: noisedash
+    spec:
+      containers:
+      - name: noisedash
+        image: noisedash/noisedash:latest
+        ports:
+        - containerPort: 1432
+        volumeMounts:
+        - name: db
+          mountPath: /var/noisedash/db
+        - name: samples
+          mountPath: /var/noisedash/samples
+        - name: config
+          mountPath: /var/noisedash/config/default.json
+          subPath: config.json
+      volumes:
+      - name: db
+        persistentVolumeClaim:
+          claimName: db-pvc
+      - name: samples
+        persistentVolumeClaim:
+          claimName: samples-pvc
+      - name: config
+        configMap:
+          name: noisedashcfg
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: noisedash
+spec:
+  selector:
+    app: noisedash
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 1432
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noisedashcfg
+data:
+  config.json: |
+    {
+      "Server": {
+        "listeningPort": 1432,
+        "sessionFileStorePath": "sessions",
+        "sampleUploadPath": "samples",
+        "maxSampleSize": 10737418240,
+        "logFile": "log/noisedash.log",
+        "tls": false,
+        "tlsKey": "certs/key.pem",
+        "tlsCert": "certs/cert.pem"
+      }
+    }
+# ---
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   annotations:
+#     cert-manager.io/cluster-issuer: letsencrypt-prod
+#     kubernetes.io/ingress.class: nginx
+#     kubernetes.io/tls-acme: "true"
+#     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+#     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+#   labels:
+#     app.kubernetes.io/instance: noisedash
+#   name: noisedashingress
+# spec:
+#   rules:
+#   - host: noisedash.freshbrewed.science
+#     http:
+#       paths:
+#       - backend:
+#           service:
+#             name: noisedash
+#             port:
+#               number: 80
+#         path: /
+#         pathType: ImplementationSpecific
+#   tls:
+#   - hosts:
+#     - noisedash.freshbrewed.science
+#     secretName: noisedash-tls


### PR DESCRIPTION
Adds support for running the container as a non-root user using the standard PUID and PGID environment variables. The entrypoint script now dynamically creates or reuses users/groups and fixes permissions on writable paths, excluding node_modules for performance.

Also bumps base image to node:18 due to compatibility issues with installing gosu in node:16 (Debian Buster). Apologies for the version change — it was required to support a secure setup without breaking ACLs.

Closes #72